### PR TITLE
Added additional functionality for extracting data from NWIS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,7 @@ docs/_build/
 # PyBuilder
 target/
 .spyderproject
+ 
+# PyCharm
+.idea/
+.ipynb_checkpoints/

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,4 +10,4 @@ Development Lead
 Contributors
 ------------
 
-None yet. Why not be the first?
+* Joseph Hughes <jdhughes@usgs.gov>

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -30,7 +30,11 @@ History
 
 * Added tests & documentation.
 
-0.1.5 (2018-02-02)
+0.1.5 (2018-02-13)
 ----------------------
 
-* Added a parameter for requesting different parameters from NWIS (thanks @jdhughes-usgs!)
+* Added a parameter (parameterCd) for requesting different parameters from NWIS (thanks @jdhughes-usgs!)
+* Added functionality to pass a either a string for the site id or a list of sites ids
+* Added functionality to query NWIS for all data for a specified parameterCD for a specified state
+* Added functionality to query NWIS for all data for a specified parameterCD for a specified county (a list of county ids can be provided)
+* Revised pandas dataframe column names to include the site id, NWIS parameterCd statistic, and the NWIS parameterCD variable description (for example, '07228000 - Mean Discharge, cubic feet per second')

--- a/NWIS trial run.ipynb
+++ b/NWIS trial run.ipynb
@@ -2,341 +2,434 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
+    "%matplotlib inline\n",
     "import hydrofunctions as hf"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "ename": "TypeError",
-     "evalue": "__init__() should return None, not 'NWIS'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[1;32m<ipython-input-2-586d41cb7113>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m()\u001b[0m\n\u001b[0;32m      1\u001b[0m \u001b[0mstart\u001b[0m \u001b[1;33m=\u001b[0m \u001b[1;34m\"2014-05-01\"\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      2\u001b[0m \u001b[0mend\u001b[0m \u001b[1;33m=\u001b[0m \u001b[1;34m\"2014-06-01\"\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m----> 3\u001b[1;33m \u001b[0mfirst\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mhf\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mNWIS\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m\"01585200\"\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;34m\"dv\"\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mstart\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mend\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[1;31mTypeError\u001b[0m: __init__() should return None, not 'NWIS'"
-     ]
-    }
-   ],
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
-    "start = \"2014-05-01\"\n",
-    "end = \"2014-06-01\"\n",
-    "first = hf.NWIS(\"01585200\", \"dv\", start, end)"
+    "### Get data for a streamflow gage"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "You must call .get_data() before calling .json().\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "start = \"2013-01-01\"\n",
+    "end = \"2013-02-01\"\n",
+    "first = hf.NWIS(\"01638500\", \"dv\", start, end)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "first.json()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "You must call .get_data() before calling .df().\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "first.df()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<hydrofunctions.station.NWIS at 0x2004db1b860>"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "first.get_data()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>value</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>datetime</th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>2014-05-01</th>\n",
-       "      <td>12.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2014-05-02</th>\n",
-       "      <td>4.9</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2014-05-03</th>\n",
-       "      <td>3.6</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2014-05-04</th>\n",
-       "      <td>3.4</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2014-05-05</th>\n",
-       "      <td>3.1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2014-05-06</th>\n",
-       "      <td>2.5</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2014-05-07</th>\n",
-       "      <td>3.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2014-05-08</th>\n",
-       "      <td>2.3</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2014-05-09</th>\n",
-       "      <td>2.2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2014-05-10</th>\n",
-       "      <td>2.9</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2014-05-11</th>\n",
-       "      <td>2.3</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2014-05-12</th>\n",
-       "      <td>2.1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2014-05-13</th>\n",
-       "      <td>2.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2014-05-14</th>\n",
-       "      <td>2.1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2014-05-15</th>\n",
-       "      <td>2.2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2014-05-16</th>\n",
-       "      <td>34.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2014-05-17</th>\n",
-       "      <td>2.9</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2014-05-18</th>\n",
-       "      <td>2.3</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2014-05-19</th>\n",
-       "      <td>2.1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2014-05-20</th>\n",
-       "      <td>2.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2014-05-21</th>\n",
-       "      <td>2.6</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2014-05-22</th>\n",
-       "      <td>3.3</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2014-05-23</th>\n",
-       "      <td>1.8</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2014-05-24</th>\n",
-       "      <td>1.7</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2014-05-25</th>\n",
-       "      <td>1.6</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2014-05-26</th>\n",
-       "      <td>1.5</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2014-05-27</th>\n",
-       "      <td>9.2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2014-05-28</th>\n",
-       "      <td>3.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2014-05-29</th>\n",
-       "      <td>5.8</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2014-05-30</th>\n",
-       "      <td>2.2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2014-05-31</th>\n",
-       "      <td>1.6</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2014-06-01</th>\n",
-       "      <td>1.4</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "            value\n",
-       "datetime         \n",
-       "2014-05-01   12.0\n",
-       "2014-05-02    4.9\n",
-       "2014-05-03    3.6\n",
-       "2014-05-04    3.4\n",
-       "2014-05-05    3.1\n",
-       "2014-05-06    2.5\n",
-       "2014-05-07    3.0\n",
-       "2014-05-08    2.3\n",
-       "2014-05-09    2.2\n",
-       "2014-05-10    2.9\n",
-       "2014-05-11    2.3\n",
-       "2014-05-12    2.1\n",
-       "2014-05-13    2.0\n",
-       "2014-05-14    2.1\n",
-       "2014-05-15    2.2\n",
-       "2014-05-16   34.0\n",
-       "2014-05-17    2.9\n",
-       "2014-05-18    2.3\n",
-       "2014-05-19    2.1\n",
-       "2014-05-20    2.0\n",
-       "2014-05-21    2.6\n",
-       "2014-05-22    3.3\n",
-       "2014-05-23    1.8\n",
-       "2014-05-24    1.7\n",
-       "2014-05-25    1.6\n",
-       "2014-05-26    1.5\n",
-       "2014-05-27    9.2\n",
-       "2014-05-28    3.0\n",
-       "2014-05-29    5.8\n",
-       "2014-05-30    2.2\n",
-       "2014-05-31    1.6\n",
-       "2014-06-01    1.4"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "first.df()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "value    34.0\n",
-       "dtype: float64"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "first.df().max()"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Plot the data for a stream gage"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "second = hf.NWIS(\"01585200\", \"dv\", \"2014-05-01\", \"2014-05-03\").get_data().df().mean()"
+    "first.df().plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Get data for a second gage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "second = hf.NWIS(\"01585200\", \"dv\", \"2014-05-01\", \"2014-05-03\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "second.get_data().df().mean()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Plot the data for the second gage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "second.df().plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sites = ['07227500', '07228000', '07233500', '07235000', '07295500', '07297910', '07298500', '07299540',\n",
+    "         '07299670', '07299890', '07300000', '07301300', '07301410', '07308200', '07308500', '07311600',\n",
+    "         '07311630', '07311700', '07311782', '07311783', '07311800', '07311900', '07312100', '07312200',\n",
+    "         '07312500', '07312700', '07314500', '07314900', '07315200', '07315500', '07342465', '07342480',\n",
+    "         '07342500', '07343000', '07343200', '07343500', '07344210', '07344500', '07346000']\n",
+    "mult = hf.NWIS(sites, \"dv\", \"2018-01-01\", \"2018-01-31\")\n",
+    "print('No. sites: {}'.format(len(sites)))\n",
+    "mult.get_data().df().mean()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mult.get_data().df()['07228000 - Mean Discharge, cubic feet per second'].plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Get individual value (`iv`) data for a groundwater well"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "third = hf.NWIS([\"380616075380701\",\"394008077005601\"], \"iv\", \"2018-01-01\", \"2018-01-31\", parameterCd='72019')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "third.get_data().df().mean()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Plot the individual value data for a groundwater well"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "third.df().plot(marker='o', mfc='white', ms=4, mec='black', color='black')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Download discharge data for two stations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "start = \"2013-01-01\"\n",
+    "end = \"2014-12-31\"\n",
+    "sites = [\"01638500\", \"01646502\"]\n",
+    "test = hf.get_nwis(sites, \"dv\", start, end)\n",
+    "actual = hf.extract_nwis_df(test)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "actual.columns"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Create a table of discharge data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "actual"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Plot discharge data for two stations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "actual.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Download stage data for two stations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "start = \"2013-01-01\"\n",
+    "end = \"2014-12-31\"\n",
+    "sites = [\"01644148\", \"01651750\"]\n",
+    "test = hf.get_nwis(sites, \"dv\", start, end, parameterCd='00065')\n",
+    "actual = hf.extract_nwis_df(test)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "scrolled": false
    },
+   "outputs": [],
+   "source": [
+    "actual"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Plot stage data for two stations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "actual.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Download groundwater data for two stations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "start = \"2013-01-01\"\n",
+    "end = \"2014-12-31\"\n",
+    "sites = [\"385638077220101\", \"390623077314201\"]\n",
+    "test = hf.get_nwis(sites, \"dv\", start, end, parameterCd='72019')\n",
+    "actual = hf.extract_nwis_df(test)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Plot maximum and minimum groundwater data for two stations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "actual.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Download all streamflow data for the state of Virginia"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "start = \"2017-01-01\"\n",
+    "end = \"2017-12-31\"\n",
+    "vas = hf.get_nwis(None, \"dv\", start, end, stateCd='va')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vad = hf.extract_nwis_df(vas)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vad.mean()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Plot all streamflow data for the state of Virginia"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vad.plot(legend=None)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Download all streamflow data for Fairfax and Prince William counties in the state of Virginia"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "start = \"2017-01-01\"\n",
+    "end = \"2017-12-31\"\n",
+    "cs = hf.get_nwis(None, \"dv\", start, end, countyCd=['51059', '51061'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cd = hf.extract_nwis_df(cs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Plot all streamflow data for Fairfax and Prince William counties in the state of Virginia"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cd.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": []
   }
@@ -344,9 +437,9 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [isolate]",
+   "display_name": "Python [conda root]",
    "language": "python",
-   "name": "Python [isolate]"
+   "name": "conda-root-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -358,9 +451,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.5.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/hydrofunctions/station.py
+++ b/hydrofunctions/station.py
@@ -72,7 +72,9 @@ class NWIS(Station):
                  start_date=None,
                  end_date=None,
                  parameterCd='00060'):
-        self.name = name
+
+        sites = typing.check_NWIS_name(name)
+        self.name = sites
         self.service = service
         self.start_date = start_date
         self.end_date = end_date

--- a/hydrofunctions/typing.py
+++ b/hydrofunctions/typing.py
@@ -23,12 +23,25 @@ import re
 def check_NWIS_name(input):
     """Checks that the USGS station id is valid.
     """
+    msg = "NWIS station id(s) should be a string or list of strings, " + \
+          "often in the form of an eight digit number enclosed in quotes"
+    if input is None:
+        return None
     if isinstance(input, str):
-        return input
+        input = input.split(',')
+    elif isinstance(input, list):
+        for s in input:
+            if not isinstance(s, str):
+                raise TypeError(msg)
     else:
-        raise TypeError("NWIS station id should be a string, often in the \
-                        form of an eight digit number enclosed in quotes")
+        raise TypeError(msg)
 
+    # format site(s)
+    sites = '{}'.format(input[0])
+    if len(input) > 1:
+        for s in input[1:]:
+            sites += ',{}'.format(s)
+    return sites
 
 def check_NWIS_service(input):
     """Checks that the service is valid: either iv or dv"""

--- a/tests/test_hydrofunctions.py
+++ b/tests/test_hydrofunctions.py
@@ -56,6 +56,24 @@ class TestHydrofunctions(unittest.TestCase):
         self.assertIs(type(actual), pd.core.frame.DataFrame,
                       msg="Did not return a df")
 
+    def test_hf_extract_nwis_stations_df(self):
+        # TODO: I need to make a response fixture to test this out!!
+        sites = ["01638500", "01646502"]
+        test = hf.get_nwis(sites, "dv",
+                           "2013-01-01", "2013-01-05")
+        actual = hf.extract_nwis_df(test)
+        self.assertIs(type(actual), pd.core.frame.DataFrame,
+                      msg="Did not return a df")
+
+    def test_hf_extract_nwis_iv_gwstations_df(self):
+        # TODO: I need to make a response fixture to test this out!!
+        sites = ["380616075380701", "394008077005601"]
+        test = hf.get_nwis(sites, "iv",
+                           "2018-01-01", "2018-01-05", parameterCd='72019')
+        actual = hf.extract_nwis_df(test)
+        self.assertIs(type(actual), pd.core.frame.DataFrame,
+                      msg="Did not return a df")
+
     @unittest.skip("What happens if NWIS returns valid response with no data?")
     def test_hf_extract_nwis_raises_exception_when_df_is_empty(self):
         # See line 78 in hydrofunctions

--- a/tests/test_station.py
+++ b/tests/test_station.py
@@ -136,5 +136,13 @@ class TestNWIS(unittest.TestCase):
         actual = station.NWIS(name, service, start, end)
         actual.get_data().df() #returns a dataframe
 
+    def test_NWIS_sites_returns_df(self):
+        name = ["01638500", "01646502"]
+        service = "dv"
+        start = "2011-01-01"
+        end = "2011-01-02"
+        actual = station.NWIS(name, service, start, end)
+        actual.get_data().df() #returns a dataframe
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
Summary of changes in the pull request:

* Added functionality to pass a either a string for the site id or a list of sites ids
* Added functionality to query NWIS for all data for a specified parameterCD for a specified state
* Added functionality to query NWIS for all data for a specified parameterCD for a specified county (a list of county ids can be provided)
* Revised pandas dataframe column names to include the site id, NWIS parameterCd statistic, and the NWIS parameterCD variable description (for example, '07228000 - Mean Discharge, cubic feet per second')

Added additional unit tests to testing framework.

Tested discharge, stage, and depth to water (groundwater) for daily (`dv`) and individual (`iv`) values.

Examples of extracting different data types has been added to `NWIS trial run.ipynb`

If you are ok with the changes I have what I was hoping to present in the python class we will be running at the end of the month. So whenever you are ready to make the next release.