### PR TITLE
Bugfix read parquet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
 
   # the "--only-binary" option was added in pip 7 back in 2015; still to be safe, upgrade pip
   - pip install --upgrade pip setuptools wheel
-  - pip install --only-binary=numpy,scipy,pandas,Ipython,matplotlib,pyarrow numpy scipy pandas ipython matplotlib pyarrow
+  #- pip install --only-binary=numpy,scipy,pandas,Ipython,matplotlib,pyarrow numpy scipy pandas ipython matplotlib pyarrow
 
   # Install codecov so I can use it (and coverage.py) to run setup.py
   # However, keep codecov in setup.py so that it gets installed for local usage too.

--- a/hydrofunctions/hydrofunctions.py
+++ b/hydrofunctions/hydrofunctions.py
@@ -702,4 +702,4 @@ def save_parquet(filename, dataframe, hf_meta):
     hf_string = json.dumps(hf_meta).encode()
     meta_dict[b"hydrofunctions_meta"] = hf_string
     table = table.replace_schema_metadata(meta_dict)
-    pq.write_table(table, filename)
+    pq.write_table(table, filename, compression='gzip')

--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,10 @@ stem = r"https://raw.githubusercontent.com/mroberge/hydrofunctions/master/_stati
 requirements = [
     "matplotlib",
     "numpy>=1.16.0",
-    "pandas",
+    "panda==1.0.5",
     "requests",
     "IPython",
-    "pyarrow==0.16.0",
+    "pyarrow==0.17.1",
     "ipykernel",
     "nbsphinx",
 ]
@@ -45,7 +45,7 @@ test_requirements = [
 
 setup(
     name="hydrofunctions",
-    version="0.2.0",
+    version="0.2.1dev",
     description="A suite of convenience functions for exploring water data in a Jupyter Notebook.",
     long_description=readme,  # + "\n\n" + history,
     long_description_content_type="text/x-rst",

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ stem = r"https://raw.githubusercontent.com/mroberge/hydrofunctions/master/_stati
 requirements = [
     "matplotlib",
     "numpy>=1.16.0",
-    "panda==1.0.5",
+    "pandas==1.0.5",
     "requests",
     "IPython",
     "pyarrow==0.17.1",

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, print_function, division, unicode_litera
 import unittest
 import matplotlib
 import pandas as pd
+print("Pandas version ", pd.__version__)
 
 from hydrofunctions import charts
 import hydrofunctions as hf

--- a/tests/test_hydrofunctions.py
+++ b/tests/test_hydrofunctions.py
@@ -599,7 +599,7 @@ class TestHydrofunctions(unittest.TestCase):
             "select_data should return an array of which columns contain the data, not the qualifiers.",
         )
 
-    def integration_test_save_read_parquet(self):
+    def test_integration_test_save_read_parquet(self):
         # This test has side effects: it will create a file.
         expected_df, expected_meta = hf.extract_nwis_df(two_sites_two_params_iv)
         filename = "test_filename_delete_me"

--- a/tests/test_hydrofunctions.py
+++ b/tests/test_hydrofunctions.py
@@ -24,6 +24,8 @@ import numpy as np
 import pyarrow as pa
 import json
 
+print("Pyarrow version: ", pa.__version__)
+
 import hydrofunctions as hf
 from .fixtures import (
     fakeResponse,


### PR DESCRIPTION
For reasons that I don't understand, hf.read_parquet causes python to fail silently. Through trial and error, I figured out that old version of Pandas (1.0.5) and Pyarrow (0.17.1) coupled with using gzip instead of the default snappy in pyarrow works.