### PR TITLE
Add feature save json

### DIFF
--- a/hydrofunctions/__init__.py
+++ b/hydrofunctions/__init__.py
@@ -78,6 +78,8 @@ from .hydrofunctions import (
     calc_freq,
     read_parquet,
     save_parquet,
+    read_json_gzip,
+    save_json_gzip,
 )
 from .station import Station, NWIS
 from .typing import (

--- a/hydrofunctions/hydrofunctions.py
+++ b/hydrofunctions/hydrofunctions.py
@@ -719,7 +719,7 @@ def read_parquet(filename):
     meta_dict = pa_table.schema.metadata
     if b"hydrofunctions_meta" in meta_dict:
         meta_string = meta_dict[b"hydrofunctions_meta"].decode()
-        meta = json.loads(meta_string, encoding="utf-8")
+        meta = json.loads(meta_string)
     else:
         meta = None
     return dataframe, meta

--- a/hydrofunctions/hydrofunctions.py
+++ b/hydrofunctions/hydrofunctions.py
@@ -740,6 +740,9 @@ def save_parquet(filename, dataframe, hf_meta):
         hf_meta (dict): a dictionary with the metadata for the NWIS data request, if it
         exists.
     """
+    if (len(filename.split('.'))==1):
+        filename = filename + '.gz.parquet'
+
     table = pa.Table.from_pandas(dataframe, preserve_index=True)
     meta_dict = table.schema.metadata
     hf_string = json.dumps(hf_meta).encode()

--- a/hydrofunctions/hydrofunctions.py
+++ b/hydrofunctions/hydrofunctions.py
@@ -11,6 +11,7 @@ import requests
 import numpy as np
 import pandas as pd
 import json
+import gzip
 import pyarrow as pa
 import pyarrow.parquet as pq
 from pandas.tseries.frequencies import to_offset
@@ -749,3 +750,40 @@ def save_parquet(filename, dataframe, hf_meta):
     meta_dict[b"hydrofunctions_meta"] = hf_string
     table = table.replace_schema_metadata(meta_dict)
     pq.write_table(table, filename, compression="gzip")
+
+
+def read_json_gzip(filename):
+    """Read a gzipped JSON file into a Python dictionary
+
+    Reads JSON files that have been zipped and returns a Python dictionary.
+    Usually the files should have an extension *.json.gz
+    Hydrofunctions uses this function to store the original JSON format WaterML
+    response from the USGS NWIS.
+
+    Args:
+        filename (str): A string with the filename and extension.
+
+    Returns:
+        a dictionary of the file contents.
+    """
+    with gzip.open(filename, 'rb') as zip_file:
+        zip_dict = json.loads(zip_file.read())
+        return zip_dict
+
+
+def save_json_gzip(filename, json_dict):
+    """Save a Python dictionary as a gzipped JSON file.
+
+    This save function is especially designed to compress and save the original
+    JSON response from the USGS NWIS. If no file extension is specified, then a
+    *.json.gz extension will be provided.
+
+    Args:
+        filename (str): A string with the filename and extension.
+        json_dict (dict): A dictionary representing the json content.
+    """
+    if (len(filename.split('.'))==1):
+        filename = filename + 'json.gz'
+
+    with gzip.open(filename, 'wt', encoding="ascii") as zip_file:
+       json.dump(json_dict, zip_file)

--- a/hydrofunctions/station.py
+++ b/hydrofunctions/station.py
@@ -109,7 +109,7 @@ class NWIS(Station):
             if (len(file.split(".")) == 1):
                 file = file + ".json.gz"
             try:
-                self._dataframe, self.meta = hf.read_parquet(file)
+                self.read(file)
                 self.ok = True
                 print("Reading data from", file)
 

--- a/hydrofunctions/station.py
+++ b/hydrofunctions/station.py
@@ -138,7 +138,7 @@ class NWIS(Station):
             except json.JSONDecodeError as err:
                 self.ok = False
                 print(f"JSON decoding error. URL: {self.response.url}")
-                raise json.JSONDecodeError(err)
+                raise err
 
         # Can I get rid of this, and only keep metadata in the meta dict?
         if self.ok:

--- a/hydrofunctions/station.py
+++ b/hydrofunctions/station.py
@@ -105,7 +105,9 @@ class NWIS(Station):
     ):
 
         self.ok = False
-        if file is not None:
+        if file:
+            if (len(file.split(".")) == 1):
+                file = file + ".json.gz"
             try:
                 self._dataframe, self.meta = hf.read_parquet(file)
                 self.ok = True

--- a/hydrofunctions/station.py
+++ b/hydrofunctions/station.py
@@ -25,7 +25,6 @@ class Station(object):
         self.site = site
         # One option is to make it so that you can pass in a get_data function
         # during the creation of an instance.
-        self.get_data = None
 
 
 class NWIS(Station):

--- a/tests/test_hydrofunctions.py
+++ b/tests/test_hydrofunctions.py
@@ -616,10 +616,10 @@ class TestHydrofunctions(unittest.TestCase):
     def test_hf_save_read_parquet_integration(self):
         # This test has side effects: it will create a file.
         expected_df, expected_meta = hf.extract_nwis_df(two_sites_two_params_iv)
-        filename = "test_filename_delete_me"
+        filename = "test_filename_delete_me.test"
         hf.save_parquet(filename, expected_df, expected_meta)
         actual_df, actual_meta = hf.read_parquet(filename)
-        os.remove("test_filename_delete_me")
+        os.remove("test_filename_delete_me.test")
         self.assertEqual(
             expected_df.index.freq,
             actual_df.index.freq,
@@ -644,10 +644,27 @@ class TestHydrofunctions(unittest.TestCase):
 
     @mock.patch("pyarrow.parquet.write_table")
     def test_hf_save_parquet(self, mock_write):
-        filename = "expected_filename"
+        filename = "expected_filename.test"
         expected_df, expected_meta = hf.extract_nwis_df(two_sites_two_params_iv)
         hf.save_parquet(filename, expected_df, expected_meta)
-        pass
+
+    @mock.patch("gzip.open")
+    @mock.patch("json.loads")
+    def test_hf_read_json_gz(self, mock_json, mock_gzip):
+        expected = two_sites_two_params_iv
+        mock_json.return_value = expected
+        actual = hf.read_json_gzip("filename")
+        mock_gzip.assert_called_with("filename", "rb")
+        self.assertEqual(actual, expected)
+
+    @mock.patch("gzip.open")
+    @mock.patch("json.dump")
+    def test_hf_save_json_gz(self, mock_json, mock_gzip):
+        expected = two_sites_two_params_iv
+        expected_filename = "save.fake"
+        hf.save_json_gzip(expected_filename, expected)
+        mock_gzip.assert_called_with(expected_filename, "wt", encoding="ascii")
+        #mock_json.assert_called_with(expected)
 
 
 if __name__ == "__main__":

--- a/tests/test_hydrofunctions.py
+++ b/tests/test_hydrofunctions.py
@@ -616,10 +616,10 @@ class TestHydrofunctions(unittest.TestCase):
     def test_hf_save_read_parquet_integration(self):
         # This test has side effects: it will create a file.
         expected_df, expected_meta = hf.extract_nwis_df(two_sites_two_params_iv)
-        filename = "test_filename_delete_me.test"
+        filename = "test_filename_delete_me.parquet"
         hf.save_parquet(filename, expected_df, expected_meta)
         actual_df, actual_meta = hf.read_parquet(filename)
-        os.remove("test_filename_delete_me.test")
+        os.remove("test_filename_delete_me.parquet")
         self.assertEqual(
             expected_df.index.freq,
             actual_df.index.freq,
@@ -637,14 +637,14 @@ class TestHydrofunctions(unittest.TestCase):
         meta_dict[b"hydrofunctions_meta"] = meta_string
         expected_table = expected_table.replace_schema_metadata(meta_dict)
         mock_read.return_value = expected_table
-        actual_df, actual_meta = hf.read_parquet("fake_filename")
+        actual_df, actual_meta = hf.read_parquet("fake_filename.parquet")
 
         assert_frame_equal(expected_df, actual_df)
         self.assertEqual(expected_meta, actual_meta, "The metadata dict has changed.")
 
     @mock.patch("pyarrow.parquet.write_table")
     def test_hf_save_parquet(self, mock_write):
-        filename = "expected_filename.test"
+        filename = "expected_filename.parquet"
         expected_df, expected_meta = hf.extract_nwis_df(two_sites_two_params_iv)
         hf.save_parquet(filename, expected_df, expected_meta)
 

--- a/tests/test_hydrofunctions.py
+++ b/tests/test_hydrofunctions.py
@@ -653,18 +653,18 @@ class TestHydrofunctions(unittest.TestCase):
     def test_hf_read_json_gz(self, mock_json, mock_gzip):
         expected = two_sites_two_params_iv
         mock_json.return_value = expected
-        actual = hf.read_json_gzip("filename")
-        mock_gzip.assert_called_with("filename", "rb")
+        actual = hf.read_json_gzip("filename.json.gz")
+        mock_gzip.assert_called_with("filename.json.gz", "rb")
         self.assertEqual(actual, expected)
 
     @mock.patch("gzip.open")
     @mock.patch("json.dump")
     def test_hf_save_json_gz(self, mock_json, mock_gzip):
         expected = two_sites_two_params_iv
-        expected_filename = "save.fake"
+        expected_filename = "save.json.gz"
         hf.save_json_gzip(expected_filename, expected)
         mock_gzip.assert_called_with(expected_filename, "wt", encoding="ascii")
-        #mock_json.assert_called_with(expected)
+        mock_json.assert_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_station.py
+++ b/tests/test_station.py
@@ -1030,6 +1030,27 @@ End:   expected end"""
         test_nwis.save(expected_filename)
         mock_save.assert_called_once_with(expected_filename, expected_df, expected_meta)
 
+    @mock.patch("hydrofunctions.hydrofunctions.save_json_gzip")
+    def test_NWIS_save_calls_save_gz(self, mock_save):
+        expected_filename = "expected_filename.gz"
+        expected_json = "expected json"
+        test_nwis = TestingNWIS()
+        test_nwis.json = expected_json
+        test_nwis.save(expected_filename)
+        mock_save.assert_called_once_with(expected_filename, expected_json)
+
+    def test_NWIS_save_gz_raises_error_if_no_json(self):
+        expected_filename = "expected_filename.gz"
+        test_nwis = TestingNWIS()
+        with self.assertRaises(AttributeError):
+            test_nwis.save(expected_filename)
+
+    def test_NWIS_save_gz_raises_error_if_unrecognized_file_extension(self):
+        expected_filename = "expected_filename.weird"
+        test_nwis = TestingNWIS()
+        with self.assertRaises(OSError):
+            test_nwis.save(expected_filename)
+
     @mock.patch("hydrofunctions.hydrofunctions.read_parquet")
     def test_NWIS_read_calls_read_parquet(self, mock_read):
         expected_filename = "expected_filename.parquet"
@@ -1051,6 +1072,23 @@ End:   expected end"""
             test_nwis.meta,
             "The metadata were not retrieved by NWIS.read().",
         )
+
+    @mock.patch("hydrofunctions.hydrofunctions.read_json_gzip")
+    def test_NWIS_read_calls_read_json_gz(self, mock_read):
+        expected_filename = "expected_filename.json.gz"
+        expected_json = recent_only
+        mock_read.return_value = expected_json
+        expected_meta = {'USGS:01541200': {'siteName': 'WB Susquehanna River near Curwensville, PA', 'siteLatLongSrs': {'srs': 'EPSG:4326', 'latitude': 40.9614471, 'longitude': -78.5191906}, 'timeSeries': {'00010': {'variableFreq': '<0 * Minutes>', 'variableUnit': 'deg C', 'variableDescription': 'Temperature, water, degrees Celsius', 'methodID': '118850', 'methodDescription': ''}, '00060': {'variableFreq': '<0 * Minutes>', 'variableUnit': 'ft3/s', 'variableDescription': 'Discharge, cubic feet per second', 'methodID': '118849', 'methodDescription': ''}}}}
+        test_nwis = TestingNWIS()
+        test_nwis.read(expected_filename)
+        mock_read.assert_called_once_with(expected_filename)
+        actual_meta = test_nwis.meta
+        self.assertEqual(
+            actual_meta,
+            expected_meta,
+            f"The read function did not parse the json.gz file correctly. It returned"
+            f"type {type(actual_meta)} when it was expected to return type {type(expected_meta)}."
+            )
 
 
 """

--- a/tests/test_station.py
+++ b/tests/test_station.py
@@ -214,7 +214,7 @@ class TestNWISinit(unittest.TestCase):
 
     @mock.patch("hydrofunctions.hydrofunctions.read_parquet")
     def test_NWIS_init_filename_calls_read_parquet(self, mock_read):
-        expected_filename = "expected_filename"
+        expected_filename = "expected_filename.parquet"
         expected_meta = "expected meta"
         expected_df = pd.DataFrame(
             np.random.randn(5, 1),
@@ -266,7 +266,7 @@ class TestNWISinit(unittest.TestCase):
         mock_extract_nwis_df.return_value = (mock_df, mock_meta)
 
         # mock_save
-        expected_filename = "expected_filename"
+        expected_filename = "expected_filename.parquet"
         mock_save.return_value = "expected self"
 
         # Create an NWIS with a filename, but the filename doesn't exist.

--- a/tests/test_station.py
+++ b/tests/test_station.py
@@ -1019,7 +1019,7 @@ End:   expected end"""
 
     @mock.patch("hydrofunctions.hydrofunctions.save_parquet")
     def test_NWIS_save_calls_save_parquet(self, mock_save):
-        expected_filename = "expected_filename"
+        expected_filename = "expected_filename.parquet"
         expected_meta = "expected meta"
         expected_df = "expected df"
         mock_start = "expected start"
@@ -1032,7 +1032,7 @@ End:   expected end"""
 
     @mock.patch("hydrofunctions.hydrofunctions.read_parquet")
     def test_NWIS_read_calls_read_parquet(self, mock_read):
-        expected_filename = "expected_filename"
+        expected_filename = "expected_filename.parquet"
         expected_meta = "expected meta"
         expected_df = "expected df"
         mock_start = "expected start"


### PR DESCRIPTION
Add the ability to save the original WaterML JSON as a zipped JSON file. I made this the default.