### PR TITLE
Bugfix rdb parsing

### DIFF
--- a/docs/notebooks/Writing_Valid_Requests_for_NWIS.ipynb
+++ b/docs/notebooks/Writing_Valid_Requests_for_NWIS.ipynb
@@ -174,7 +174,7 @@
     "\n",
     "You are required to set **one** of these parameters, but only one.\n",
     "\n",
-    "All of these parameters are demonstrated in [Selecting Sites](Selecting_Sites.html)"
+    "All of these parameters are demonstrated in [Selecting Sites](Selecting_Sites.ipynb)"
    ]
   },
   {

--- a/hydrofunctions/hydrofunctions.py
+++ b/hydrofunctions/hydrofunctions.py
@@ -710,9 +710,8 @@ def read_parquet(filename):
         filename (str): A string with the filename and extension.
 
     Returns:
-        dataframe (pd.DataFrame): a pandas dataframe.
-        meta (dict): a dictionary with the metadata for the NWIS data request, if it
-        exists.
+        * dataframe (pd.DataFrame): a pandas dataframe.
+        * meta (dict): a dictionary with the metadata for the NWIS data request, if it exists.
     """
     pa_table = pq.read_table(filename)
     dataframe = pa_table.to_pandas()
@@ -738,8 +737,7 @@ def save_parquet(filename, dataframe, hf_meta):
     Args:
         filename (str): A string with the filename and extension.
         dataframe (pd.DataFrame): a pandas dataframe.
-        hf_meta (dict): a dictionary with the metadata for the NWIS data request, if it
-        exists.
+        hf_meta (dict): a dictionary with the metadata for the NWIS data request, if it exists.
     """
     if (len(filename.split('.'))==1):
         filename = filename + '.gz.parquet'
@@ -753,10 +751,10 @@ def save_parquet(filename, dataframe, hf_meta):
 
 
 def read_json_gzip(filename):
-    """Read a gzipped JSON file into a Python dictionary
+    """Read a gzipped JSON file into a Python dictionary.
 
     Reads JSON files that have been zipped and returns a Python dictionary.
-    Usually the files should have an extension *.json.gz
+    Usually the files should have an extension .json.gz
     Hydrofunctions uses this function to store the original JSON format WaterML
     response from the USGS NWIS.
 
@@ -776,7 +774,7 @@ def save_json_gzip(filename, json_dict):
 
     This save function is especially designed to compress and save the original
     JSON response from the USGS NWIS. If no file extension is specified, then a
-    *.json.gz extension will be provided.
+    .json.gz extension will be provided.
 
     Args:
         filename (str): A string with the filename and extension.

--- a/hydrofunctions/usgs_rdb.py
+++ b/hydrofunctions/usgs_rdb.py
@@ -369,11 +369,12 @@ def peaks(site):
     Returns:
         a hydroRDB object or tuple consisting of the header and a table. The header
         is a multi-line string of metadata supplied by the USGS with the data series.
-        The table is a dataframe containing the annual peak discharge series.
+        The table is a dataframe containing the annual peak discharge series. You can
+        use these data to conduct a flood frequency analysis.
 
     **Example:**
 
-        >>> test = data_catalog('01542500')
+        >>> test = hf.peaks('01542500')
         >>> test
         hydroRDB(header=<a mulit-line string of the header>,
                  table=<a Pandas dataframe>)

--- a/hydrofunctions/usgs_rdb.py
+++ b/hydrofunctions/usgs_rdb.py
@@ -165,7 +165,17 @@ def read_rdb(text):
             header=None,
             names=columns,
             dtype={"site_no": str, "parameter_cd": str},
+            # When converted like this, poorly-formed dates will be saved as strings
+            parse_dates=True,
+            #If dates are converted like this, then poorly formed dates will stop the process
+            #converters={"peak_dt": pd.to_datetime},
         )
+        # Another approach would be to convert date columns later, and catch errors
+        #try:
+        #   outputDF.peak_dt = pd.to_datetime(outputDF.peak_dt)
+        #except ValueError as err:
+        #   print(f"Unable to parse date. reason: '{str(err)}'.")
+
     except:
         print(
             "There appears to be an error processing the file that the USGS "
@@ -176,6 +186,7 @@ def read_rdb(text):
         raise
     # outputDF.outputDF.filter(like='_cd').columns
     # TODO: code columns ('*._cd') should be interpreted as strings.
+    # TODO: date columns ('*_dt') should be converted to dates.
 
     return header, outputDF, columns, dtypes
 

--- a/hydrofunctions/usgs_rdb.py
+++ b/hydrofunctions/usgs_rdb.py
@@ -124,6 +124,7 @@ def read_rdb(text):
             A long string containing the contents of a rdb file. A common way
             to obtain these would be from the .text property of a requests
             response, as in the example usage below.
+
     Returns:
         header (multi-line string):
             Every commented line at the top of the rdb file is marked with a
@@ -435,7 +436,7 @@ def rating_curve(site):
 
     **Example:**
 
-        >>> test = data_catalog('01542500')
+        >>> test = rating_curve('01542500')
         >>> test
         hydroRDB(header=<a mulit-line string of the header>,
                  table=<a Pandas dataframe>)
@@ -489,9 +490,12 @@ def stats(site, statReportType="daily", **kwargs):
             The gage ID number for the site, or a series of gage IDs separated
             by commas, like this: '01546500,01548000'.
 
-        statReportType ('annual'|'monthly'|'daily'):
+        statReportType ('daily'|'monthly'|'annual'):
             There are three different types of report that you can request.
-            - 'daily' (default): this
+
+            - 'daily' (default): calculate statistics for each of 365 days.
+            - 'monthly': calculate statistics for each of the twelve months.
+            - 'annual': calculate annual statistics for each year since the start of the record.
 
     Returns:
         a hydroRDB object or tuple consisting of the header and a table. The header
@@ -500,7 +504,8 @@ def stats(site, statReportType="daily", **kwargs):
         site.
 
     Raises:
-        HTTPError when a non-200 http status code is returned.
+        HTTPError
+            when a non-200 http status code is returned.
 
     **Example:**
 

--- a/hydrofunctions/usgs_rdb.py
+++ b/hydrofunctions/usgs_rdb.py
@@ -397,10 +397,12 @@ def peaks(site):
     print("Retrieving annual peak discharges for site #", site, " from ", url)
     response = get_usgs_RDB_service(url, headers)
     header, outputDF, columns, dtype = read_rdb(response.text)
-    outputDF.peak_dt = pd.to_datetime(outputDF.peak_dt)
-
-    outputDF.set_index("peak_dt", inplace=True)
-
+    try:
+        outputDF.peak_dt = pd.to_datetime(outputDF.peak_dt)
+        outputDF.set_index("peak_dt", inplace=True)
+    except ValueError as err:
+        print(f"Unable to parse date. reason: '{str(err)}'.  As a result of this"
+            "problem, the dataframe will not use the date as the index."   )
     output_obj = hydroRDB(header, outputDF, columns, dtype)
     return output_obj
 

--- a/hydrofunctions/usgs_rdb.py
+++ b/hydrofunctions/usgs_rdb.py
@@ -27,6 +27,8 @@ class hydroRDB:
         dtypes (str):
             A string from the rdb file that gives the data type and length of
             each column.
+        rdb (str):
+            The complete original text of the rdb file.
 
     **Properties:**
         **header** (str):
@@ -39,6 +41,8 @@ class hydroRDB:
         **dtypes** (str):
             A string from the rdb file that gives the data type and length of
             each column.
+        **rdb** (str):
+            The original, unparsed rdb file as returned by the USGS.
 
         You can also access the header and the dataframe as a named tuple::
 
@@ -52,11 +56,12 @@ class hydroRDB:
         - You can read more about the RDB format here: https://pubs.usgs.gov/of/2003/ofr03123/6.4rdb_format.pdf
     """
 
-    def __init__(self, header, table, columns, dtypes):
+    def __init__(self, header, table, columns, dtypes, rdb_str):
         self.header = header
         self.table = table
         self.columns = columns
         self.dtypes = dtypes
+        self.rdb = rdb_str
 
     def __iter__(self):
         return iter((self.header, self.table))
@@ -233,7 +238,7 @@ def site_file(site):
         columns,
         dtype,
     ) = read_rdb(response.text)
-    output_obj = hydroRDB(header, outputDF, columns, dtype)
+    output_obj = hydroRDB(header, outputDF, columns, dtype, response.text)
 
     return output_obj
 
@@ -278,7 +283,7 @@ def data_catalog(site):
         columns,
         dtype,
     ) = read_rdb(response.text)
-    output_obj = hydroRDB(header, outputDF, columns, dtype)
+    output_obj = hydroRDB(header, outputDF, columns, dtype, response.text)
 
     return output_obj
 
@@ -366,7 +371,7 @@ def field_meas(site):
 
     outputDF.set_index("measurement_dt", inplace=True)
 
-    output_obj = hydroRDB(header, outputDF, columns, dtype)
+    output_obj = hydroRDB(header, outputDF, columns, dtype, response.text)
 
     return output_obj
 
@@ -416,7 +421,7 @@ def peaks(site):
 
     # peak_date might be a string, or it might be a datetime. Both work as an index
     outputDF.set_index("peak_dt", inplace=True)
-    output_obj = hydroRDB(header, outputDF, columns, dtype)
+    output_obj = hydroRDB(header, outputDF, columns, dtype, response.text)
     return output_obj
 
 
@@ -478,7 +483,7 @@ def rating_curve(site):
                      skiprows=2
                      )
     """
-    output_obj = hydroRDB(header, outputDF, columns, dtype)
+    output_obj = hydroRDB(header, outputDF, columns, dtype, response.text)
     return output_obj
 
 
@@ -580,5 +585,5 @@ def stats(site, statReportType="daily", **kwargs):
 
     header, outputDF, columns, dtype = read_rdb(response.text)
 
-    output_obj = hydroRDB(header, outputDF, columns, dtype)
+    output_obj = hydroRDB(header, outputDF, columns, dtype, response.text)
     return output_obj

--- a/hydrofunctions/usgs_rdb.py
+++ b/hydrofunctions/usgs_rdb.py
@@ -361,7 +361,11 @@ def field_meas(site):
         columns,
         dtype,
     ) = read_rdb(response.text)
-    outputDF.measurement_dt = pd.to_datetime(outputDF.measurement_dt)
+
+    try:
+        outputDF.measurement_dt = pd.to_datetime(outputDF.measurement_dt)
+    except ValueError as err:
+        print(f"Unable to parse the measurement_dt field as a date. reason: '{str(err)}'.")
 
     # An attempt to use the tz_cd column to make measurement_dt timezone aware.
     # outputDF.tz_cd.replace({np.nan: 'UTC'}, inplace=True)
@@ -370,9 +374,7 @@ def field_meas(site):
     # outputDF['datetime'] = outputDF[['measurement_dt', 'tz_cd']].apply(lambda x: f(*x), axis=1)
 
     outputDF.set_index("measurement_dt", inplace=True)
-
     output_obj = hydroRDB(header, outputDF, columns, dtype, response.text)
-
     return output_obj
 
 

--- a/hydrofunctions/usgs_rdb.py
+++ b/hydrofunctions/usgs_rdb.py
@@ -410,10 +410,11 @@ def peaks(site):
     header, outputDF, columns, dtype = read_rdb(response.text)
     try:
         outputDF.peak_dt = pd.to_datetime(outputDF.peak_dt)
-        outputDF.set_index("peak_dt", inplace=True)
     except ValueError as err:
-        print(f"Unable to parse date. reason: '{str(err)}'.  As a result of this"
-            "problem, the dataframe will not use the date as the index."   )
+        print(f"Unable to parse the peak_dt field as a date. reason: '{str(err)}'.")
+
+    # peak_date might be a string, or it might be a datetime. Both work as an index
+    outputDF.set_index("peak_dt", inplace=True)
     output_obj = hydroRDB(header, outputDF, columns, dtype)
     return output_obj
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -26,6 +26,7 @@ from .fixtures_usgs_rdb import (
     field_fixture,
     rating_fixture,
     peaks_fixture,
+    parsing_error_fixture,
 )
 
 

--- a/tests/fixtures_usgs_rdb.py
+++ b/tests/fixtures_usgs_rdb.py
@@ -19,6 +19,10 @@ This file contains the following test fixtures:
         - Header contains many 'messages', including two tables.
         - dtypes contain two date columns.
         13 columns, 18 data rows.
+
+    - parsing_error_fixture: a peaks rdb file with a bad date of 1881-00-00.
+        13 columns
+        5 data rows, but 1 has a bad date.
 """
 
 
@@ -194,4 +198,87 @@ USGS	01542500	1971-02-28		18400	6	8.79
 USGS	01542500	2016-02-04		7880	6	6.05
 USGS	01542500	2017-05-30		15700	6	8.43
 USGS	01542500	2018-09-10	21:30	41000	6	13.22
+"""
+
+#The following is shortened from: https://nwis.waterdata.usgs.gov/nwis/peak?site_no=06813500&agency_cd=USGS&format=rdb
+# You can reproduce this with: hf.peaks('06813500')
+parsing_error_fixture = """#
+# U.S. Geological Survey
+# National Water Information System
+# Retrieved: 2021-03-24 21:15:41 EDT
+#
+# ---------------------------------- WARNING ----------------------------------------
+# Some of the data that you have obtained from this U.S. Geological Survey database
+# may not have received Director's approval. Any such data values are qualified
+# as provisional and are subject to revision. Provisional data are released on the
+# condition that neither the USGS nor the United States Government may be held liable
+# for any damages resulting from its use.
+#
+# More data may be available offline.
+# For more information on these data,  contact  USGS Water Data Inquiries.
+# This file contains the annual peak streamflow data.
+#
+# This information includes the following fields:
+#
+#  agency_cd     Agency Code
+#  site_no       USGS station number
+#  peak_dt       Date of peak streamflow (format YYYY-MM-DD)
+#  peak_tm       Time of peak streamflow (24 hour format, 00:00 - 23:59)
+#  peak_va       Annual peak streamflow value in cfs
+#  peak_cd       Peak Discharge-Qualification codes (see explanation below)
+#  gage_ht       Gage height for the associated peak streamflow in feet
+#  gage_ht_cd    Gage height qualification codes
+#  year_last_pk  Peak streamflow reported is the highest since this year
+#  ag_dt         Date of maximum gage-height for water year (if not concurrent with peak)
+#  ag_tm         Time of maximum gage-height for water year (if not concurrent with peak
+#  ag_gage_ht    maximum Gage height for water year in feet (if not concurrent with peak
+#  ag_gage_ht_cd maximum Gage height code
+#
+# Sites in this file include:
+#  USGS 06813500 Missouri River at Rulo, NE
+#
+# Peak Streamflow-Qualification Codes(peak_cd):
+#   1 ... Discharge is a Maximum Daily Average
+#   2 ... Discharge is an Estimate
+#   3 ... Discharge affected by Dam Failure
+#   4 ... Discharge less than indicated value,
+#           which is Minimum Recordable Discharge at this site
+#   5 ... Discharge affected to unknown degree by
+#           Regulation or Diversion
+#   6 ... Discharge affected by Regulation or Diversion
+#   7 ... Discharge is an Historic Peak
+#   8 ... Discharge actually greater than indicated value
+#   9 ... Discharge due to Snowmelt, Hurricane,
+#           Ice-Jam or Debris Dam breakup
+#   A ... Year of occurrence is unknown or not exact
+#   Bd ... Day of occurrence is unknown or not exact
+#   Bm ... Month of occurrence is unknown or not exact
+#   C ... All or part of the record affected by Urbanization,
+#            Mining, Agricultural changes, Channelization, or other
+#   F ... Peak supplied by another agency
+#   O ... Opportunistic value not from systematic data collection
+#   R ... Revised
+#
+# Gage height qualification codes(gage_ht_cd,ag_gage_ht_cd):
+#   1 ... Gage height affected by backwater
+#   2 ... Gage height not the maximum for the year
+#   3 ... Gage height at different site and(or) datum
+#   4 ... Gage height below minimum recordable elevation
+#   5 ... Gage height is an estimate
+#   6 ... Gage datum changed during this year
+#   7 ... Debris, mud, or hyper-concentrated flow
+#   8 ... Gage height tidally affected
+#   Bd ... Day of occurrence is unknown or not exact
+#   Bm ... Month of occurrence is unknown or not exact
+#   F ... Peak supplied by another agency
+#   R ... Revised
+#
+#
+agency_cd	site_no	peak_dt	peak_tm	peak_va	peak_cd	gage_ht	gage_ht_cd	year_last_pk	ag_dt	ag_tm	ag_gage_ht	ag_gage_ht_cd
+5s	15s	10d	6s	8s	33s	8s	27s	4s	10d	6s	8s	27s
+USGS	06813500	1881-00-00				22.90	Bm					
+USGS	06813500	1950-04-29		185000					1950-04-30		21.60	
+USGS	06813500	1951-06-03		175000					1951-05-02		20.90	
+USGS	06813500	1952-04-22		358000		25.60						
+USGS	06813500	1953-06-28		117000	6	17.47						
 """

--- a/tests/test_usgs_rdb.py
+++ b/tests/test_usgs_rdb.py
@@ -461,6 +461,18 @@ class TestReadRdb(unittest.TestCase):
             expected_url, headers=expected_headers, params=expected_params
         )
 
+    @mock.patch("requests.get")
+    def test_peaks_handles_parsing_error(self, mock_get):
+        site_id = "06813500" # This site returns data with a malformed date.
+        expected_status_code = 200
+        expected_text = parsing_error_fixture
+        expected = fakeResponse(code=expected_status_code, text=expected_text)
+        mock_get.return_value = expected
+
+        # This will cause a parsing error that must be dealt with.
+        actual = hf.peaks(site_id)
+
+
 
 class Test_hydroRDB(unittest.TestCase):
     """Test the hydroRDB class.

--- a/tests/test_usgs_rdb.py
+++ b/tests/test_usgs_rdb.py
@@ -23,6 +23,7 @@ from .fixtures import (
     field_fixture,
     rating_fixture,
     peaks_fixture,
+    parsing_error_fixture,
 )
 
 

--- a/tests/test_usgs_rdb.py
+++ b/tests/test_usgs_rdb.py
@@ -508,3 +508,15 @@ class Test_hydroRDB(unittest.TestCase):
         actual_repr = actual.__repr__()
         # actual._repr_html_() requires that table is a dataframe with a _repr_html_()
         # actual_html_repr = actual._repr_html_()
+
+    def test_hydroRDB_can_return_tuple(self):
+        header = "expected header"
+        table = pd.DataFrame({"A":[1,2], "B":[3,4]})
+        columns = "expected columns"
+        dtypes = "expected dtypes"
+        rdb = "expected rdb file"
+        actual = hf.hydroRDB(header, table, columns, dtypes, rdb)
+        self.assertIsInstance(actual, hf.hydroRDB)
+        head, table = actual
+        self.assertIsInstance(head, str)
+        self.assertIsInstance(table, pd.DataFrame)

--- a/tests/test_usgs_rdb.py
+++ b/tests/test_usgs_rdb.py
@@ -488,7 +488,8 @@ class Test_hydroRDB(unittest.TestCase):
         table = "expected table"
         columns = "expected columns"
         dtypes = "expected dtypes"
-        actual = hf.hydroRDB(header, table, columns, dtypes)
+        rdb = "expected rdb file"
+        actual = hf.hydroRDB(header, table, columns, dtypes, rdb)
         self.assertIsInstance(actual, hf.hydroRDB)
 
     def test_hydroRDB_has_properties_and_methods(self):
@@ -496,12 +497,14 @@ class Test_hydroRDB(unittest.TestCase):
         table = "expected table"
         columns = "expected columns"
         dtypes = "expected dtypes"
-        actual = hf.hydroRDB(header, table, columns, dtypes)
+        rdb = "expected rdb file"
+        actual = hf.hydroRDB(header, table, columns, dtypes, rdb)
         self.assertIsInstance(actual, hf.hydroRDB)
         self.assertEqual(actual.header, header)
         self.assertEqual(actual.table, table)
         self.assertEqual(actual.columns, columns)
         self.assertEqual(actual.dtypes, dtypes)
+        self.assertEqual(actual.rdb, rdb)
         actual_repr = actual.__repr__()
         # actual._repr_html_() requires that table is a dataframe with a _repr_html_()
         # actual_html_repr = actual._repr_html_()


### PR DESCRIPTION
This attempts to address problems highlighted in Issue #80 . An error is raised when hf.peaks(site) attempts to coerce a malformed string to a datetime. "1881-00-00" couldn't be parsed.

The solution is to attempt the conversion, but leave the timestamps as a string if there is a problem. Then raise a warning describing the problem. It would be nice if I could also supply a solution, like to drop the bad row or repair the bad value, then directions to convert the column to datetime.

This issue affects every RDB file from the USGS: most have date columns, and they also have strings and floats that need to be recognized.

Possible solutions:

- [dylan-profiler/visions](https://dylan-profiler.github.io/visions/index.html) is a great package that seems to do a better job than my current system of automatically recognizing data types in CSV files.
- Using the column header of the RDB file. These are ugly, but possibly useful.
- preserve the original text from the response so that it can be parsed again if needed, or the original values can be examined. Maybe add as a .rdb attribute to the hydroRDB class.