### PR TITLE
Add feature verbose mode

### DIFF
--- a/hydrofunctions/hydrofunctions.py
+++ b/hydrofunctions/hydrofunctions.py
@@ -130,6 +130,7 @@ def get_nwis(
     bBox=None,
     parameterCd="all",
     period=None,
+    verbose=True,
 ):
     """Request stream gauge data from the USGS NWIS.
 
@@ -180,6 +181,10 @@ def get_nwis(
             NWIS period code. Default is `None`.
                 * Format is "PxxD", where xx is the number of days before today.
                 * Either use start_date or period, but not both.
+        
+        verbose (bool):
+            Use print statements if True (default); set to False if this function will 
+            be used in other software and you don't want print statements.
 
     Returns:
         a response object. This function will always return the response,
@@ -284,7 +289,8 @@ def get_nwis(
     url = "https://waterservices.usgs.gov/nwis/"
     url = url + service + "/?"
     response = requests.get(url, params=values, headers=header)
-    print("Requested data from", response.url)
+    if verbose:
+        print("Requested data from", response.url)
     # requests will raise a 'ConnectionError' if the connection is refused
     # or if we are disconnected from the internet.
 

--- a/hydrofunctions/station.py
+++ b/hydrofunctions/station.py
@@ -96,6 +96,9 @@ class NWIS(Station):
 
             Zipped JSON files will save the original WaterML JSON provided by the NWIS.
             Parquet files will save the dataframe and the metadata for the NWIS object.
+
+        verbose (bool):
+            Print output for actions such as making data requests. Default is True.
     """
 
     def __init__(
@@ -110,6 +113,7 @@ class NWIS(Station):
         parameterCd="all",
         period=None,
         file=None,
+        verbose=True,
     ):
 
         self.ok = False
@@ -119,7 +123,8 @@ class NWIS(Station):
             try:
                 self.read(file)
                 self.ok = True
-                print("Reading data from", file)
+                if verbose:
+                    print("Reading data from", file)
 
             except OSError as err:
                 # File does not exist yet, we'll make it later.
@@ -136,6 +141,7 @@ class NWIS(Station):
                 bBox=bBox,
                 parameterCd=parameterCd,
                 period=period,
+                verbose=verbose,
             )
             try:
                 self.json = self.response.json()
@@ -143,7 +149,8 @@ class NWIS(Station):
                 self.ok = self.response.ok
                 if file is not None:
                     self.save(file)
-                    print("Saving data to", file)
+                    if verbose:
+                        print("Saving data to", file)
             except json.JSONDecodeError as err:
                 self.ok = False
                 print(f"JSON decoding error. URL: {self.response.url}")

--- a/tests/test_hydrofunctions.py
+++ b/tests/test_hydrofunctions.py
@@ -460,6 +460,34 @@ class TestHydrofunctions(unittest.TestCase):
         with self.assertRaises(ValueError):
             hf.get_nwis("01541000", start_date="2014-01-01", period="P1D")
 
+    @mock.patch("requests.get")
+    @mock.patch("builtins.print")
+    def test_hf_get_nwis_verbose_True(self, mock_print, mock_get):
+        # testing a print function from https://realpython.com/lessons/mocking-print-unit-tests/
+        expected = fakeResponse()
+        expected.status_code = 200
+        expected.reason = "any text"
+        expected.url = "expected url"
+        mock_get.return_value = expected
+        expected_text = "Requested data from"
+
+        actual = hf.get_nwis("01582500", period="P2D", verbose=True)
+
+        mock_print.assert_called_with(expected_text, expected.url)
+
+    @mock.patch("requests.get")
+    @mock.patch("builtins.print")
+    def test_hf_get_nwis_verbose_False(self, mock_print, mock_get):
+        # testing a print function from https://realpython.com/lessons/mocking-print-unit-tests/
+        expected = fakeResponse()
+        expected.status_code = 200
+        expected.reason = "any text"
+        mock_get.return_value = expected
+
+        actual = hf.get_nwis("01582500", period="P2D", verbose=False)
+
+        mock_print.assert_not_called()
+
     def test_hf_nwis_custom_status_codes_returns_None_for_200(self):
         fake = fakeResponse()
         fake.status_code = 200

--- a/tests/test_station.py
+++ b/tests/test_station.py
@@ -117,6 +117,7 @@ class TestNWISinit(unittest.TestCase):
         default_stateCd = None
         default_countyCd = None
         default_bBox = None
+        default_verbose = True
 
         mock_get_nwis_property.return_value = "expected"
         mock_get_nwis.return_value = fakeResponse()
@@ -133,6 +134,7 @@ class TestNWISinit(unittest.TestCase):
             stateCd=default_stateCd,
             countyCd=default_countyCd,
             bBox=default_bBox,
+            verbose=default_verbose,
         )
         self.assertTrue(mock_get_nwis_property)
 
@@ -160,6 +162,7 @@ class TestNWISinit(unittest.TestCase):
             stateCd=None,
             countyCd=None,
             bBox=None,
+            verbose=True,
         )
         self.assertTrue(mock_get_nwis_property)
 


### PR DESCRIPTION
See Issue #93
This creates a verbose mode that is on in default so that you get the normal behavior of printing the url when you request data. This mode can be turned off so that requests to the NWIS do not generate a print statement.

This does not fix the many other reasons that lines are printed, however...