### PR TITLE
Create publishing Github actions

### DIFF
--- a/.github/workflows/publish-release-to-pypi.yml
+++ b/.github/workflows/publish-release-to-pypi.yml
@@ -1,9 +1,7 @@
 name: Publish Python 🐍 distributions 📦 to TestPyPI
 
-on:
-  pull_request:
-    branches:
-      - master
+on: release
+
 jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions to TestPyPI
@@ -21,8 +19,7 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: |
         python -m build --sdist --wheel --outdir dist/ .
-    - name: Publish distribution 📦 to Test PyPI
+    - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@master
       with:
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
+        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Created two Github actions:

1. publish to test.pypi when a pull request to master occurs
2. publish to pypi for a release