### PR TITLE
fix URL print out for hf.stats

### DIFF
--- a/src/hydrofunctions/usgs_rdb.py
+++ b/src/hydrofunctions/usgs_rdb.py
@@ -638,7 +638,7 @@ def stats(site, statReportType="daily", verbose=True, **kwargs):
     response = get_usgs_RDB_service(url, headers, params)
     if verbose:
         print(
-            f"Retrieved {params['statReportType']} statistics for site #{site} from {url}"
+            f"Retrieved {params['statReportType']} statistics for site #{site} from {response.url}"
         )
 
     header, outputDF, columns, dtype = read_rdb(response.text)


### PR DESCRIPTION
Issue #118  the hf.stats function prints the incorrect url when it requests data. This fix will print the correct URL. None of the other functions in this module are affected.